### PR TITLE
Refactored class in PieceBase.cs

### DIFF
--- a/ChessWPF/ChessManagementClasses/Bishop.cs
+++ b/ChessWPF/ChessManagementClasses/Bishop.cs
@@ -3,15 +3,15 @@
     public class Bishop : PieceBase
 	{
 		public override ChessPieceType Type => ChessPieceType.Bishop;
-
         public override string ImagePath { get => Color == PieceColor.White
                                                         ? "/Assets/WhiteBishop.png"
                                                         : "/Assets/BlackBishop.png"; }
-
         public Bishop(PieceColor color) : base(color) { }
-
         public Bishop(Bishop b) : base(b) { }
-
+        public override PieceBase Clone()
+        {
+            return new Bishop(this);
+        }
         public override List<MoveBase> GetPossibleMoves(Board board, Position position)
 		{
 			List<MoveBase> moves = new List<MoveBase>();

--- a/ChessWPF/ChessManagementClasses/King.cs
+++ b/ChessWPF/ChessManagementClasses/King.cs
@@ -3,14 +3,15 @@
     public class King : PieceBase
 	{
 		public override ChessPieceType Type => ChessPieceType.King;
-
         public override string ImagePath { get => Color == PieceColor.White
                                                         ? "/Assets/WhiteKing.png"
                                                         : "/Assets/BlackKing.png"; }
-
         public King(PieceColor color) : base(color) { }
         public King(King k) : base(k) { }
-
+        public override PieceBase Clone()
+        {
+            return new King(this);
+        }
         public override List<MoveBase> GetPossibleMoves(Board board, Position position)
 		{
 			List<MoveBase> moves = new List<MoveBase>();

--- a/ChessWPF/ChessManagementClasses/Knight.cs
+++ b/ChessWPF/ChessManagementClasses/Knight.cs
@@ -3,16 +3,16 @@
     public class Knight : PieceBase
 	{
 		public override ChessPieceType Type { get => ChessPieceType.Knight; }
-
         public override string ImagePath { get => Color == PieceColor.White
                                                         ? "/Assets/WhiteKnight.png"
                                                         : "/Assets/BlackKnight.png"; }
-
         public Knight(PieceColor color) : base(color) { }
-
 		public Knight(Knight k) : base(k) { }
-
-		public override List<MoveBase> GetPossibleMoves(Board board, Position position)
+        public override PieceBase Clone()
+        {
+            return new Knight(this);
+        }
+        public override List<MoveBase> GetPossibleMoves(Board board, Position position)
 		{
 			List<MoveBase> moves = new List<MoveBase>();
 

--- a/ChessWPF/ChessManagementClasses/Pawn.cs
+++ b/ChessWPF/ChessManagementClasses/Pawn.cs
@@ -3,15 +3,15 @@
     public class Pawn : PieceBase
     {
         public override ChessPieceType Type { get => ChessPieceType.Pawn; }
-
         public override string ImagePath { get => Color == PieceColor.White 
                                                         ? "/Assets/WhitePawn.png"
                                                         : "/Assets/BlackPawn.png"; }
-
         public Pawn(PieceColor color) : base(color) { }
-
         public Pawn(Pawn p) : base(p) { }
-
+        public override PieceBase Clone()
+        {
+            return new Pawn(this);
+        }
         public override List<MoveBase> GetPossibleMoves(Board board, Position position)
         {
             List<MoveBase> moves = new List<MoveBase>();

--- a/ChessWPF/ChessManagementClasses/PieceBase.cs
+++ b/ChessWPF/ChessManagementClasses/PieceBase.cs
@@ -2,23 +2,32 @@
 {
     public abstract class PieceBase
     {
-        protected bool previeousHasMoved;
-        protected bool hasMoved = false;
+        protected bool previousHasMoved;
+        protected bool hasMoved;
+
+        private static readonly Dictionary<ChessPieceType, char> pieceCharMap = new()
+        {
+            { ChessPieceType.Pawn, 'p' },
+            { ChessPieceType.Rook, 'r' },
+            { ChessPieceType.Knight, 'n' },
+            { ChessPieceType.Bishop, 'b' },
+            { ChessPieceType.Queen, 'q' },
+            { ChessPieceType.King, 'k' }
+        };
 
         public abstract ChessPieceType Type { get; }
         public PieceColor Color { get; }
+        public bool PreviousHasMoved { get => previousHasMoved; }
+        public abstract string ImagePath { get; }
         public bool HasMoved
         {
             get => hasMoved;
             set
             {
-                previeousHasMoved = hasMoved;
+                previousHasMoved = hasMoved;
                 hasMoved = value;
             }
         }
-        public bool PreviousHasMoved { get => previeousHasMoved; }
-
-        public abstract string ImagePath { get; }
 
         public PieceBase(PieceColor color)
         {
@@ -29,29 +38,10 @@
         {
             Color = other.Color;
             hasMoved = other.hasMoved;
-            previeousHasMoved = other.previeousHasMoved;
+            previousHasMoved = other.previousHasMoved;
         }
 
-        public PieceBase Clone()
-        {
-            switch(Type)
-            {
-                case ChessPieceType.Pawn:
-                    return new Pawn(this as Pawn);
-                case ChessPieceType.Rook:
-                    return new Rook(this as Rook);
-                case ChessPieceType.Knight:
-                    return new Knight(this as Knight);
-                case ChessPieceType.Bishop:
-                    return new Bishop(this as Bishop);
-                case ChessPieceType.Queen:
-                    return new Queen(this as Queen);
-                case ChessPieceType.King:
-                    return new King(this as King);
-                default:
-                    throw new Exception("Invalid piece type");
-            }
-        }
+        public abstract PieceBase Clone();
 
         public abstract List<MoveBase> GetPossibleMoves(Board board, Position current);
 
@@ -61,8 +51,11 @@
 
             foreach (MoveBase move in moves)
             {
-                if (board.GetPiece(move.EndPosition) != null && board.GetPiece(move.EndPosition).Type == ChessPieceType.King)
+                var piece = board.GetPiece(move.EndPosition);
+                if (piece != null && piece.Type == ChessPieceType.King)
+                {
                     return true;
+                }
             }
 
             return false;
@@ -79,36 +72,16 @@
             }
 
             if (Board.IsPositionValid(current) && board.GetPiece(current).Color != Color)
+            {
                 yield return current;
+            }
 
             yield break;
         }
 
         public char GetPieceChar()
         {
-            char pieceChar = ' ';
-
-            switch (Type)
-            {
-                case ChessPieceType.Pawn:
-					pieceChar = 'p';
-					break;
-                case ChessPieceType.Rook:
-                    pieceChar = 'r';
-                    break;
-                case ChessPieceType.Knight:
-					pieceChar = 'n';
-					break;
-                case ChessPieceType.Bishop:
-                    pieceChar = 'b';
-                    break;
-                case ChessPieceType.Queen:
-					pieceChar = 'q';
-					break;
-                case ChessPieceType.King:
-					pieceChar = 'k';
-					break;
-            }
+            var pieceChar = pieceCharMap[Type];
 
             return Color == PieceColor.White ? char.ToUpper(pieceChar) : pieceChar;
         }

--- a/ChessWPF/ChessManagementClasses/Queen.cs
+++ b/ChessWPF/ChessManagementClasses/Queen.cs
@@ -3,16 +3,16 @@
     public class Queen : PieceBase
 	{
 		public override ChessPieceType Type => ChessPieceType.Queen;
-
         public override string ImagePath { get => Color == PieceColor.White
                                                         ? "/Assets/WhiteQueen.png"
                                                         : "/Assets/BlackQueen.png"; }
-
         public Queen(PieceColor color) : base(color) { }
-
 		public Queen(Queen q) : base(q) { }
-
-		public override List<MoveBase> GetPossibleMoves(Board board, Position position)
+        public override PieceBase Clone()
+        {
+            return new Queen(this);
+        }
+        public override List<MoveBase> GetPossibleMoves(Board board, Position position)
 		{
 			List<MoveBase> moves = new List<MoveBase>();
 

--- a/ChessWPF/ChessManagementClasses/Rook.cs
+++ b/ChessWPF/ChessManagementClasses/Rook.cs
@@ -3,16 +3,16 @@
     public class Rook : PieceBase
 	{
 		public override ChessPieceType Type => ChessPieceType.Rook;
-
         public override string ImagePath { get => Color == PieceColor.White
 														? "/Assets/WhiteRook.png"
                                                         : "/Assets/BlackRook.png"; }
-
         public Rook(PieceColor color) : base(color) { }
-
 		public Rook(Rook r) : base(r) { }
-
-		public override List<MoveBase> GetPossibleMoves(Board board, Position position)
+        public override PieceBase Clone()
+        {
+            return new Rook(this);
+        }
+        public override List<MoveBase> GetPossibleMoves(Board board, Position position)
 		{
 			List<MoveBase> moves = new List<MoveBase>();
 


### PR DESCRIPTION
Removed switch statement in _Clone_ method and replaced it with an abstract class.
In result, fixed excessive coupling by adding an implementation in the following classes:

- [Bishop](https://github.com/DeLinev/ChessWPF/blob/master/ChessWPF/ChessManagementClasses/Bishop.cs)
- [King](https://github.com/DeLinev/ChessWPF/blob/master/ChessWPF/ChessManagementClasses/King.cs)
- [Knight](https://github.com/DeLinev/ChessWPF/blob/master/ChessWPF/ChessManagementClasses/Knight.cs)
- [Pawn](https://github.com/DeLinev/ChessWPF/blob/master/ChessWPF/ChessManagementClasses/Pawn.cs)
- [Queen](https://github.com/DeLinev/ChessWPF/blob/master/ChessWPF/ChessManagementClasses/Queen.cs)
- [Rook](https://github.com/DeLinev/ChessWPF/blob/master/ChessWPF/ChessManagementClasses/Rook.cs)

Renamed variable _previeousHasMoved_ to _previousHasMoved_.
Replaced second switch statement with a dictionary containing letter references to the corresponding chess pieces.

Closes #9  